### PR TITLE
Split into apache-sedona-core (lightweight) and apache-sedona (metapackage)

### DIFF
--- a/recipe/bld_apache_sedona_core.bat
+++ b/recipe/bld_apache_sedona_core.bat
@@ -1,0 +1,4 @@
+@echo off
+
+"%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit 1

--- a/recipe/build_apache_sedona_core.sh
+++ b/recipe/build_apache_sedona_core.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+"$PYTHON" -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -11,42 +11,56 @@ source:
   sha256: cd195a86e3b68e8ccbe8dd66333d7c2403609937f4d3c13c5a627779eec6b7ce
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
 
-requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - {{ compiler('c') }}
-    - {{ stdlib("c") }}
-    - setuptools >=68.0.0                    # [py>=313]
-    - setuptools                             # [py<313]
-    - wheel
-  host:
-    - pip
-    - python
-    - setuptools >=68.0.0                    # [py>=313]
-    - setuptools                             # [py<313]
-  run:
-    - attrs
-    - pyspark
-    - python
-    - shapely >=1.7.0
-    - rasterio >=1.2.10
-    # Explicit dependencies to ensure compatible versions for rasterio/GDAL stack
-    - libxml2
-    - glib
-    - pcre2
+outputs:
+  - name: apache-sedona-core
+    script: build_apache_sedona_core.sh   # [unix]
+    script: bld_apache_sedona_core.bat    # [win]
+    requirements:
+      build:
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - {{ compiler('c') }}
+        - {{ stdlib("c") }}
+      host:
+        - pip
+        - python
+        - setuptools >=68.0.0
+        - wheel
+      run:
+        - python
+        - attrs
+        - shapely >=1.7.0
+    test:
+      imports:
+        - sedona
+      commands:
+        - pip check
+      requires:
+        - pip
 
-test:
-  imports:
-    - sedona
-    - sedona.core
-  commands:
-    - pip check
-  requires:
-    - pip
+  - name: apache-sedona
+    requirements:
+      host:
+        - python
+      run:
+        - {{ pin_subpackage('apache-sedona-core', exact=True) }}
+        - python
+        - pyspark
+        - rasterio >=1.2.10
+        # Explicit dependencies to ensure compatible versions for rasterio/GDAL stack
+        - libxml2
+        - glib
+        - pcre2
+    test:
+      imports:
+        - sedona
+        - sedona.core
+      commands:
+        - pip check
+      requires:
+        - pip
 
 about:
   home: https://sedona.apache.org


### PR DESCRIPTION
Refactors the recipe into a multi-output build that produces two packages from the same source tarball:

- **`apache-sedona-core`** — ships the `sedona/` Python package and the `geomserde_speedup` C extension with a lightweight dependency surface (`python`, `attrs`, `shapely`). Per-platform build, includes the C compiler in `requirements.build`.
- **`apache-sedona`** — zero-file metapackage that exact-pins `apache-sedona-core` and adds the `pyspark` + `rasterio` / GDAL stack required by the Spark integration.

Existing `apache-sedona` users get a transparent upgrade: the same `sedona/` files are now installed via `apache-sedona-core`, and `apache-sedona` continues to provide the same set of run dependencies. SedonaDB and other non-Spark consumers can depend on `apache-sedona-core` directly instead of pulling in the ~700 MB Spark stack.

## Background

This supersedes [conda-forge/staged-recipes#33194](https://github.com/conda-forge/staged-recipes/pull/33194), which originally proposed `apache-sedona-core` as a separate feedstock. Per @traversaro's review on that PR, a multi-output recipe in this single feedstock is the conda-forge canonical pattern (mirroring how `pyarrow` / `pyarrow-core` are produced from `arrow-cpp-feedstock`) and avoids needing to coordinate version bumps across two feedstocks.

## Local validation

`conda-build recipe/ -m .ci_support/osx_arm64_python3.12.____cpython.yaml` produced both outputs and passed all tests:

- `apache-sedona-core-1.9.0-py312haaf164e_1.conda` — 354 files (Python + compiled `geomserde_speedup`)
- `apache-sedona-1.9.0-py312h1f38498_1.conda` — 0 files, pure metapackage

`conda-smithy lint` is clean.

## Notes

- Build number bumped from 0 to 1 since this is a structural change.
- The metapackage exact-pins `apache-sedona-core` so a single version+build of `apache-sedona` corresponds to a single matching variant of `apache-sedona-core`.

cc @paleolimbot @traversaro